### PR TITLE
Bug Fix - Edge Weights

### DIFF
--- a/src/jmapping/fitting/nerve.py
+++ b/src/jmapping/fitting/nerve.py
@@ -81,17 +81,13 @@ class Nerve:
             Complete list of simplices
 
         """
-
-        result = defaultdict(list)
-        weights = []
+    
+        result = []
         # Create links when clusters from different hypercubes have members with the same sample id.
         candidates = itertools.combinations(nodes.keys(), 2)
         for candidate in candidates:
             # if there are non-unique members in the union
             overlap = len(set(nodes[candidate[0]]).intersection(nodes[candidate[1]]))
             if overlap > 0:
-                result[candidate[0]].append(candidate[1])
-                weights.append(1 / overlap)
-
-        edges = [(x, end, w) for x in result for end in result[x] for w in weights]
-        return edges
+                result.append((candidate[0], candidate[1], round(1 / overlap, 3)))
+        return result


### PR DESCRIPTION
Fixed bug where computed edge weights were not being assigned properly in `nerve.py`

Visual confirmation and checks preformed and it appears to work properly now. That said, I would double check this with `graph.edges(data=True)` to confirm everything is being assigned properly.