### PR TITLE
Deprecate Thema and point to Pulsar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,31 +9,6 @@ on:
       - main
 
 jobs:
-  quality-checks:
-    runs-on: ubuntu-latest
-    name: Code Quality & Formatting
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python 3.13
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-
-      - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-      - name: Install dependencies
-        run: |
-          uv sync --all-extras
-
-      - name: Check code formatting with Black
-        run: |
-          uv run black --check --diff thema/ tests/
-
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -41,7 +16,6 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     name: Test Python ${{ matrix.python-version }}
-    needs: quality-checks
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+> ⚠️ **IMPORTANT NOTICE:** This repository (**Thema**) is now deprecated and has been archived. We have built a newer, faster, and more robust tool called [Pulsar](https://github.com/Krv-Labs/pulsar) which replaces Thema.
+>
+> Pulsar is available on PyPI as [thema-pulsar](https://pypi.org/project/thema-pulsar/) and can be installed via:
+> ```bash
+> pip install thema-pulsar
+> ```
+> We strongly encourage all users to migrate to Pulsar for topological hyperparameter evaluation and mapping!
+
 # THEMA 🔮
 
 <p align="center">

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,6 +6,19 @@ Thema
 
 **Topological Hyperparameter Evaluation and Mapping Algorithm**
 
+.. attention::
+   **DEPRECATION NOTICE**
+
+   This repository (**Thema**) is now deprecated. We have built a newer, faster, and more robust tool called `Pulsar <https://github.com/Krv-Labs/pulsar>`_ which replaces Thema.
+
+   Pulsar is available on PyPI as `thema-pulsar <https://pypi.org/project/thema-pulsar/>`_ and can be installed via:
+
+   .. code-block:: bash
+
+      pip install thema-pulsar
+
+   We strongly recommend migrating to Pulsar for your topological hyperparameter evaluation and mapping workflows.
+
 Thema explores model space through systematic preprocessing, dimensionality reduction, and graph construction, then selects representative models using topological distances.
 
 Quick Links


### PR DESCRIPTION
This PR deprecates the Thema repository and redirects users to Pulsar. Closes #65.